### PR TITLE
Implementation of hw.test as generic + methods

### DIFF
--- a/pegas/NAMESPACE
+++ b/pegas/NAMESPACE
@@ -49,3 +49,6 @@ S3method(plot, spectrum)
 
 S3method(plot, summary.loci)
 S3method(print, summary.loci)
+
+S3method(hw.test, loci)
+S3method(hw.test, genind)

--- a/pegas/R/hw.test.R
+++ b/pegas/R/hw.test.R
@@ -53,7 +53,19 @@ expand.genotype <- function(n, alleles = NULL, ploidy = 2, matrix = FALSE)
     ans
 }
 
-hw.test <- function(x, B = 1000)
+
+## CODE MODIFICATION BY THIBAUT JOMBART
+## t.jombart@imperial.ac.uk
+## March 2015
+##
+
+## generic
+hw.test <- function (x, B=1000, ...){
+    UseMethod("hw.test")
+}
+
+## method for class 'loci'
+hw.test.loci <- function(x, B = 1000, ...)
 {
     test.polyploid <- function(x, ploidy) {
         if (ploidy < 2) return(rep(NA_real_, 3))
@@ -109,7 +121,33 @@ hw.test <- function(x, B = 1000)
         ans <- cbind(ans, "Pr.exact" = mapply(test.mc, y, ploidy))
     }
     ans
-}
+} # end hw.test.loci
+
+
+
+## method for class 'genind'
+hw.test.genind <- function(x, B=1000, ...){
+    ## checks
+    byPop <- FALSE
+    pop <- NULL
+    if(is.null(pop)) pop <- pop(x)
+    if(byPop && is.null(pop(x))){
+        warning("byPop requested but pop(x) is NULL")
+        byPop <- FALSE
+    }
+
+    ## convert genind to loci
+    x <- as.loci(x)
+
+    ## call hw.test.loci
+    out <- hw.test.loci(x=x, B=B, ...)
+
+    ## return result
+    return(out)
+} # end hw.test.genind
+
+
+
 
 ## version avec rhyper(): (Huber et al. 2006, Biometrics)
 ## (doesn't work)

--- a/pegas/man/hw.test.Rd
+++ b/pegas/man/hw.test.Rd
@@ -1,16 +1,25 @@
 \name{hw.test}
 \alias{hw.test}
+\alias{hw.test.loci}
+\alias{hw.test.genind}
 \title{Test of Hardy--Weinberg Equilibrium}
 \description{
   This function tests, for a series of loci, the hypothesis that
   genotype frequencies follow the Hardy--Weinberg equilibrium.
+  \code{hw.test} is a generic with methods for the classes
+  \code{\link{loci}} and \linkS4class{genind}. Note that the latter
+  replaces \code{HWE.test.genind} in the \code{adegenet} package.
 }
 \usage{
-hw.test(x, B = 1000)
+hw.test(x, B = 1000, \dots)
+method{hw.test}{loci}(x, B = 1000, \dots)
+method{hw.test}{genind}(x, B = 1000, \dots)
 }
 \arguments{
-  \item{x}{an object of class \code{"loci"}.}
-  \item{B}{the number of replicates for the Monte Carlo procedure.}
+  \item{x}{an object of class \code{\link{loci}} or \linkS4class{genind}.}
+  \item{B}{the number of replicates for the Monte Carlo procedure; for
+    the regular HW test, set B=0 (see details).}
+  \item{\dots}{further arguments to be passed}
 }
 \details{
   This test can be performed with any level of ploidy. Two versions
@@ -26,10 +35,20 @@ hw.test(x, B = 1000)
   possibly the \emph{P}-value from the Monte Carlo test. The rows of
   this matrix are the different loci in \code{x}.
 }
-\author{Emmanuel Paradis}
+\author{
+  Main code by Emmanuel Paradis; wrapper for \linkS4class{genind}
+  objects by Thibaut Jombart.
+}
 \examples{
 require(adegenet)
+
+## load data
 data(nancycats)
+
+## test on genind object, no permutation
+hw.test(nancycats, B=0)
+
+## test on loci object
 x <- as.loci(nancycats)
 hw.test(x)
 }

--- a/pegas/man/hw.test.Rd
+++ b/pegas/man/hw.test.Rd
@@ -12,8 +12,8 @@
 }
 \usage{
 hw.test(x, B = 1000, \dots)
-method{hw.test}{loci}(x, B = 1000, \dots)
-method{hw.test}{genind}(x, B = 1000, \dots)
+\method{hw.test}{loci}(x, B = 1000, \dots)
+\method{hw.test}{genind}(x, B = 1000, \dots)
 }
 \arguments{
   \item{x}{an object of class \code{\link{loci}} or \linkS4class{genind}.}


### PR DESCRIPTION
hw.test is a S3 generic. I expanded the arguments with ... to allow flexibility further down the line
Current methods are 
- loci
- genin

modifications also include the NAMESPACE to expot the new methods and the doc.
Passes the check, but needs the latest adegenet version which corrects rupica - it was causing an unrelated error: 
9b797f2fabd8e8c2
