### PR TITLE
Fix rhs/data issue in amova

### DIFF
--- a/pegas/R/amova.R
+++ b/pegas/R/amova.R
@@ -15,19 +15,20 @@ amova <- function(formula, data = NULL, nperm = 1000, is.squared = FALSE)
     ## keep the highest level first:
     if (length(rhs) > 1) gr.nms <- unlist(strsplit(gr.nms, "/"))
 
-    if (is.null(data) && any(sapply(gr.nms, function(x) ! is.factor(x)))) {
-        ## <FIXME>
-        ## a warning instead of an error so that StAMMP on CRAN does not
-        ## fail. I wrote to Pemberton but got no reply (2014-08-21)
-        warning("elements in the rhs of the formula are not all factors")
-        ## stop("all elements in the rhs of the formula must be factors")
-        ## </FIXME>
+    data.env <- if (is.null(data)) .GlobalEnv
+                else as.environment(data)
+    
+    if (any(sapply(gr.nms, function(x) ! is.factor(get(x, envir = data.env))))) {
+      ## <FIXME>
+      ## a warning instead of an error so that StAMMP on CRAN does not
+      ## fail. I wrote to Pemberton but got no reply (2014-08-21)
+      warning("elements in the rhs of the formula are not all factors")
+      ## stop("all elements in the rhs of the formula must be factors")
+      ## </FIXME>
     }
-
-    gr <-
-    if (is.null(data)) as.data.frame(sapply(gr.nms, get, envir = .GlobalEnv))
-    else data[gr.nms]
-
+    
+    gr <- as.data.frame(sapply(gr.nms, get, envir = data.env))
+    
     y <- get(y.nms)
     if (any(is.na(y)))
         warning("at least one missing value in the distance object.")

--- a/pegas/R/amova.R
+++ b/pegas/R/amova.R
@@ -15,7 +15,7 @@ amova <- function(formula, data = NULL, nperm = 1000, is.squared = FALSE)
     ## keep the highest level first:
     if (length(rhs) > 1) gr.nms <- unlist(strsplit(gr.nms, "/"))
 
-    if (any(sapply(gr.nms, function(x) ! is.factor(eval(parse(text = x)))))) {
+    if (is.null(data) && any(sapply(gr.nms, function(x) ! is.factor(x)))) {
         ## <FIXME>
         ## a warning instead of an error so that StAMMP on CRAN does not
         ## fail. I wrote to Pemberton but got no reply (2014-08-21)
@@ -23,6 +23,10 @@ amova <- function(formula, data = NULL, nperm = 1000, is.squared = FALSE)
         ## stop("all elements in the rhs of the formula must be factors")
         ## </FIXME>
     }
+
+    gr <-
+    if (is.null(data)) as.data.frame(sapply(gr.nms, get, envir = .GlobalEnv))
+    else data[gr.nms]
 
     y <- get(y.nms)
     if (any(is.na(y)))
@@ -33,9 +37,7 @@ amova <- function(formula, data = NULL, nperm = 1000, is.squared = FALSE)
         stop("the lhs of the formula must be either a matrix or an object of class 'dist'.")
     n <- dim(y)[1] # number of individuals
 
-    gr <-
-        if (is.null(data)) as.data.frame(sapply(gr.nms, get, envir = .GlobalEnv))
-        else data[gr.nms]
+    
     Nlv <- length(gr) # number of levels
 
 ### 5 local functions


### PR DESCRIPTION
When running amova using a data frame, it would error because of line 18, where it was trying to retrieve an object that didn't exist. This is bypassed if the data is present in a data.frame:

``` r
data(microbov)
set.seed(20150409)
mic20 <- microbov[sample(nInd(microbov), 20)]
microdf <- data.frame(other(mic20))
d <- dist(tab(mic20))
amova(d ~ spe/breed, data = microdf, nperm = 0)
```
