### PR TITLE
fix levels for print.amova

### DIFF
--- a/pegas/R/amova.R
+++ b/pegas/R/amova.R
@@ -238,7 +238,7 @@ print.amova <- function(x, ...)
             Phi[k] <- sum(sigma2[i:j]) / sum(sigma2[i:nsig])
             nms[k] <-
                 if (i == 1) paste0(lv[j], ".in.GLOBAL")
-                else paste0(lv[nsig - i + 1], ".in.", lv[nsig - j])
+                else paste0(lv[j] ".in.", lv[i - 1])
             k <- k + 1L
         }
     }


### PR DESCRIPTION
I noticed that the levels were a bit off for print.amova (they didn't match up with the analogous levels from hierfstat), so I modified them.

Here's an example showing how the output changes:

``` r
suppressPackageStartupMessages(library("poppr"))
suppressPackageStartupMessages(library("pegas"))
suppressPackageStartupMessages(library("hierfstat"))

print.amova <- function(x, ...) {
  cat("\n\tAnalysis of Molecular Variance\n\nCall: ")
  print(x$call)
  cat("\n")
  print(x$tab)
  cat("\nVariance components:\n")
  if (is.data.frame(x$varcomp)) {
    printCoefmat(x$varcomp, na.print = "")
    sigma2 <- x$varcomp$sigma2
  } else print(sigma2 <- x$varcomp)
  nsig <- length(sigma2)
  Phi <- numeric(0.5 * nsig * (nsig - 1))
  nms <- character(0.5 * nsig * (nsig - 1))
  lv <- row.names(x$tab)
  k <- 1L
  for (i in 1:(nsig - 1)) {
    for (j in i:(nsig - 1)) {
      Phi[k] <- sum(sigma2[i:j])/sum(sigma2[i:nsig])
      nms[k] <- if (i == 1) 
        paste0(lv[j], ".in.GLOBAL") else paste0(lv[j], ".in.", lv[i - 1])
      k <- k + 1L
    }
  }
  names(Phi) <- nms
  if (nsig == 3) 
    names(Phi) <- paste0(names(Phi), " (Phi_", c("CT", "ST", "SC"), ")")
  cat("\nPhi-statistics:\n")
  print(Phi)
  cat("\nVariance coefficients:\n")
  print(x$varcoef)
  cat("\n")
}

data("gtrunchier")
gt <- setNames(gtrunchier[-(1:2)], gsub("\\.", "_", names(gtrunchier[-(1:2)])))
gt <- df2genind(gt, strata = gtrunchier[1:2], ncode = 1L)

suppressWarnings(gtam <- poppr.amova(gt, ~Locality/Patch, method = "pegas", 
  quiet = TRUE))
pegas:::print.amova(gtam)
#> 
#>  Analysis of Molecular Variance
    ...
#> 
#> Variance components:
#>   Locality      Patch Individual      Error 
#>  0.9284191  0.2809404  0.6187828  0.1870398 
#> 
#> Phi-statistics:
#>     Locality.in.GLOBAL        Patch.in.GLOBAL   Individual.in.GLOBAL 
#>              0.4607123              0.6001242              0.9071847 
#>    Individual.in.Patch Individual.in.Locality      Patch.in.Locality 
#>              0.2585112              0.8278927              0.7678896 
#> 
    ...
print.amova(gtam)
#> 
#>  Analysis of Molecular Variance
    ...
#> 
#> Variance components:
#>   Locality      Patch Individual      Error 
#>  0.9284191  0.2809404  0.6187828  0.1870398 
#> 
#> Phi-statistics:
#>     Locality.in.GLOBAL        Patch.in.GLOBAL   Individual.in.GLOBAL 
#>              0.4607123              0.6001242              0.9071847 
#>      Patch.in.Locality Individual.in.Locality    Individual.in.Patch 
#>              0.2585112              0.8278927              0.7678896 
#> 
    ...
varcomp.glob(gtrunchier[1:2], gtrunchier[-(1:2)])$F
#>           Locality     Patch       Ind
#> Total    0.5158366 0.6426780 0.9152763
#> Locality 0.0000000 0.2619806 0.8250101
#> Patch    0.0000000 0.0000000 0.7628926
```

