### PR TITLE
Expanding the file name of vcf file to be read to avoid segfault.

### DIFF
--- a/pegas/R/IO.R
+++ b/pegas/R/IO.R
@@ -36,6 +36,7 @@ read.loci <-
 
 read.vcf <- function(file, from = 1, to = 1e4, which.loci = NULL, quiet = FALSE)
 {
+    file <- path.expand(file)
     f <- .VCFconnection(file)
     GZ <- if (inherits(f, "connection")) TRUE else FALSE
 


### PR DESCRIPTION
 See #28.