### PR TITLE
Fix loci subset method dispatch

### DIFF
--- a/pegas/R/summary.loci.R
+++ b/pegas/R/summary.loci.R
@@ -150,15 +150,20 @@ print.summary.loci <- function(x, ...)
 
 "[.loci" <- function (x, i, j, drop = FALSE)
 {
-    oc <- oldClass(x)
+    ## From base-R [.data.frame
+    Narg  <- nargs()  # number of arg from x,i,j that were specified
+    oc    <- oldClass(x)
     colnms.old <- names(x)
     names(x) <- colnms.new <- as.character(seq_len(ncol(x)))
     loci.nms <- names(x)[attr(x, "locicol")]
-    class(x) <- "data.frame"
-    x <- x[i, j, drop = drop]
+    if (Narg > 2) { # More than two arguments indicates that they used matrix-like subset
+       x <- NextMethod("[", drop = drop)
+    } else { # Two or fewer arguments: list-like subsetting
+       x <- NextMethod("[")
+    }
     ## restore the class and the "locicol" attribute only if there
     ## is at least 1 col *and* at least one loci returned:
-    if (class(x) == "data.frame") {
+    if (inherits(x, "data.frame")) {
         locicol <- match(loci.nms, names(x))
         locicol <- locicol[!is.na(locicol)]
         if (length(locicol)) {

--- a/pegas/man/heterozygosity.Rd
+++ b/pegas/man/heterozygosity.Rd
@@ -11,7 +11,7 @@
 \usage{
 H(x, ...)
 \method{H}{loci}(x, variance = FALSE, observed = FALSE, ...)
-\method{H}{default}(x, variance = FALSE)
+\method{H}{default}(x, variance = FALSE, ...)
 
 heterozygosity(x, variance = FALSE)
 }
@@ -22,6 +22,7 @@ heterozygosity(x, variance = FALSE)
     default being \code{FALSE}.}
   \item{observed}{a logical specifying whether to calculate the observed
     heterozygosity.}
+  \item{...}{currently unused}
 }
 \details{
   The argument \code{x} can be either a factor or a vector. If it is a

--- a/pegas/man/summary.loci.Rd
+++ b/pegas/man/summary.loci.Rd
@@ -38,10 +38,10 @@
 \details{
   Genotypes not observed in the data frame are not counted.
 
-  When using the \code{[} method, if only one column is extracted or if
-  the returned data frame has no `locus' column, then the class
-  \code{"loci"} is dropped. Use the option \code{drop = FALSE} to keep
-  the class (see examples).
+  When using the \code{[} method, if only one column is extracted and 
+  the option \code{drop = TRUE}, or if the returned data frame has no `locus' 
+  column, then the class \code{"loci"} is dropped. The option \code{drop = FALSE} 
+  (default) keeps the class (see examples).
 
   An object of class \code{"loci"} can be edited in the R data editor
   with, e.g., \code{fix(x)} or \code{x <- edit(x)}.
@@ -73,8 +73,9 @@ layout(1)
 ## compute the relative frequencies:
 rapply(s, function(x) x/sum(x), how = "replace")
 ## extract a single locus:
-jaguar[, 1] # returns a vector
-jaguar[, 1, drop = FALSE]
+jaguar[, 1]
+jaguar[, 1, drop = TRUE] # returns a vector
+jaguar[[1]]              # also returns a vector
 }
 \keyword{manip}
 \keyword{hplot}


### PR DESCRIPTION
In commit 83f2ae16bc5439827135103b8d30e55cd2327752, the subset method was no longer acting the same way as `[.data.frame` in the sense that it would treat `x[1]` as subsetting the first sample and not the first column. This fix adds that functionality back and keeps the default `drop = FALSE`.

For example, I had the following problem: If i was sub-setting my data in a list-like manner, it was interpreting that I was trying to subset the individuals:

```r
> genloc <- pegas::as.loci(nancycats)                                                                                                                                               
> genloc                                                                                                                                                                            
Allelic data frame: 237 individuals                                                                                                                                                 
                    9 loci                                                                                                                                                          
                    1 additional variable                                                                                                                                           
> attr(genloc, "locicol")                                                                                                                                                           
[1]  2  3  4  5  6  7  8  9 10                                                                                                                                                                                                                                                                                                                                
> genloc[attr(genloc, "locicol")]                                                                                                                                                   
Allelic data frame: 9 individuals                                                                                                                                                   
                    9 loci                                                                                                                                                          
                    1 additional variable      
```

This PR restores the behavior. I also updated the language and examples in the documentation.