### PR TITLE
Fst now runs in case of single population (fixes #51)

### DIFF
--- a/pegas/NEWS
+++ b/pegas/NEWS
@@ -39,6 +39,9 @@ NEW FEATURES
       new links are found: this is controlled by the new options
       'stop.criterion' and 'iter.lim'. There is also a new option
       'quiet = FALSE'.
+      
+    o Fst() now runs in the case of a single population, returning the
+      Fis (and Fit which equates 1).
 
 
 BUG FIXES

--- a/pegas/R/Fst.R
+++ b/pegas/R/Fst.R
@@ -43,7 +43,11 @@ Fst <- function(x, pop = NULL, quiet = TRUE, na.alleles = "")
         nBYpop <- tabulate(Z$pop)
         r <- length(nBYpop) # number of pops
         nbar <- N/r
-        nC <- (N - sum(nBYpop^2)/N)/(r - 1)
+        if (r == 1) {
+            nC <- 0
+        } else {
+            nC <- (N - sum(nBYpop^2)/N)/(r - 1)
+        }
         ALLELES <- getAlleles(Z)[[1]]
         h <- p <- matrix(0, r, length(ALLELES))
         for (i in 1:r) {
@@ -61,7 +65,11 @@ Fst <- function(x, pop = NULL, quiet = TRUE, na.alleles = "")
         }
         ptild <- p/(2 * nBYpop)
         pbar <- colSums(p)/(2 * N) # for each allele in the locus
-        s2 <- colSums(nBYpop * (ptild - rep(pbar, each = r))^2)/((r - 1) * nbar)
+        if (r == 1) {
+            s2 <- rep(0, length(ALLELES))
+        } else {
+            s2 <- colSums(nBYpop * (ptild - rep(pbar, each = r))^2)/((r - 1) * nbar)
+        }
         hbar <- colSums(h)/N # id.
         A <- pbar * (1 - pbar) - (r - 1) * s2/r
         a <- nbar * (s2 - (A - hbar/4)/(nbar - 1))/nC

--- a/pegas/man/Fst.Rd
+++ b/pegas/man/Fst.Rd
@@ -58,5 +58,9 @@ Rst(x, pop = NULL, quiet = TRUE, na.alleles = "")
 data(jaguar)
 Fst(jaguar)
 Rst(jaguar)
+
+## no Fst but Fit and Fis in case of single population:
+jaguar_corridor <- jaguar[jaguar$population == "Green Corridor", ]
+Fst(jaguar_corridor) 
 }
 \keyword{htest}


### PR DESCRIPTION
This PR attempts at making Fst() run, even when a single population is provided as input:

```r
library(pegas)
data(jaguar)
jaguar_corridor <- jaguar[jaguar$population == "Green Corridor", ]
Fst(jaguar_corridor)
      Fit Fst        Fis
FCA742   1 NaN 0.16760829
FCA723   1 NaN 0.41880342
FCA740   1 NaN 0.04946237
FCA441   1 NaN 0.30434783
FCA391   1 NaN 0.20930233
F98      1 NaN 0.02578797
F53      1 NaN 0.30612245
F124     1 NaN 0.01244813
F146     1 NaN 0.29350649
F85      1 NaN 0.18450185
F42      1 NaN 0.28625954
FCA453   1 NaN 0.25498008
FCA741   1 NaN 0.30434783
```

Please double check that the patch does not mess up the computation.
Perhaps the NaN should be also be replaced by NAs.
